### PR TITLE
example changes in support of vizlab#217

### DIFF
--- a/preferences.yaml
+++ b/preferences.yaml
@@ -1,0 +1,4 @@
+timetolive:
+  iris-data: 0 days
+  cars-data: 20 secs
+  Cuyahoga: 20 secs

--- a/scripts/fetch/cars.R
+++ b/scripts/fetch/cars.R
@@ -3,3 +3,5 @@ fetch.cars <- function(viz) {
   location <- viz[['location']]
   write.csv(x=cars, file=location, row.names=FALSE)
 }
+
+fetchTimestamp.cars <- vizlab:::fetchTimestamp.file

--- a/viz.yaml
+++ b/viz.yaml
@@ -23,20 +23,17 @@ fetch:
     location: data/iris.csv
     mimetype: text/csv
     scripts:
-    refetch: TRUE
   -
     id: cars-data
     location: cache/cars.csv
     fetcher: cars
     mimetype: text/csv
     scripts: scripts/fetch/cars.R
-    refetch: TRUE
   -
     id: Cuyahoga
     location: cache/fetch/CuyahogaTDS.csv
     fetcher: sciencebase
     scripts:
-    refetch: TRUE
     remoteItemId: 575d839ee4b04f417c2a03fe
     remoteFilename: CuyahogaTDS.csv
     mimetype: text/csv


### PR DESCRIPTION
https://github.com/USGS-VIZLAB/vizlab/pull/217

* introduced a preferences.yaml with a timetolive section that can include lines for some or all fetchers
* took out `refetch` options from viz.yaml
* added an example of implementing a basic `fetchTimestamp.cars`

relates to USGS-VIZLAB/vizlab#192, USGS-VIZLAB/vizlab#102